### PR TITLE
Feature/novas entidades

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - universus-network
 
   api:
-    image: evaldofires/universus-gerenciador-reserva:2.0
+    image: evaldofires/universus-gerenciador-reserva:3.0
     container_name: universus-gerenciador-reserva-api
 #    restart: unless-stopped
     depends_on:

--- a/docs/UnvierSUS.postman_collection.json
+++ b/docs/UnvierSUS.postman_collection.json
@@ -1,0 +1,140 @@
+{
+	"info": {
+		"_postman_id": "eb11303b-0979-4691-885d-32ca0b6602ec",
+		"name": "UnvierSUS",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
+		"_exporter_id": "24107059"
+	},
+	"item": [
+		{
+			"name": "Buscar Horarios Disponiveis",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"nomeMedico\":\"João\",\r\n    \"dataInicial\":\"2025-07-15\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/reservas/proximas-datas-disponiveis?nomeMedico=João&dataInicial=2025-07-15",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"reservas",
+						"proximas-datas-disponiveis"
+					],
+					"query": [
+						{
+							"key": "nomeMedico",
+							"value": "João"
+						},
+						{
+							"key": "dataInicial",
+							"value": "2025-07-15"
+						}
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Render - Buscar Horarios Disponiveis",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"nomeMedico\":\"João\",\r\n    \"dataInicial\":\"2025-07-15\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://universus-gerenciador-reserva.onrender.com/reservas/proximas-datas-disponiveis?nomeMedico=João&dataInicial=2025-07-15",
+							"protocol": "https",
+							"host": [
+								"universus-gerenciador-reserva",
+								"onrender",
+								"com"
+							],
+							"path": [
+								"reservas",
+								"proximas-datas-disponiveis"
+							],
+							"query": [
+								{
+									"key": "nomeMedico",
+									"value": "João"
+								},
+								{
+									"key": "dataInicial",
+									"value": "2025-07-15"
+								}
+							]
+						}
+					},
+					"_postman_previewlanguage": "",
+					"header": [],
+					"cookie": [
+						{
+							"expires": "Invalid Date"
+						}
+					],
+					"body": ""
+				}
+			]
+		},
+		{
+			"name": "Fazer Uma Reserva",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"nomePaciente\" : \"Antonio Peixoto\",\r\n    \"nomeMedico\"  : \"João\",\r\n    \"dataReserva\" : \"2025-07-28T17:30:00\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "http://localhost:8080/reservas"
+			},
+			"response": [
+				{
+					"name": "Render - Fazer Uma Reserva",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"nomePaciente\" : \"Antonio Peixoto\",\r\n    \"nomeMedico\"  : \"João\",\r\n    \"dataReserva\" : \"2025-07-28T17:30:00\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": "https://universus-gerenciador-reserva.onrender.com/reservas"
+					},
+					"_postman_previewlanguage": null,
+					"header": null,
+					"cookie": [],
+					"body": null
+				}
+			]
+		}
+	]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,16 @@
 			<version>5.18.0</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
 			<version>5.18.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/MedicoController.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/MedicoController.java
@@ -1,0 +1,51 @@
+package br.com.universus.gerenciador_reserva.adapter.controller;
+
+import br.com.universus.gerenciador_reserva.adapter.dto.medico.MedicoDTO;
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.CriarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.DeletarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/medicos")
+@AllArgsConstructor
+public class MedicoController {
+
+    private final BuscarMedicoUsecase buscarMedico;
+    private final CriarMedicoUsecase criarMedico;
+    private final DeletarMedicoUsecase deletarMedico;
+    private final MedicoMapper mapper;
+
+    @GetMapping("/medico")
+    public ResponseEntity<MedicoDTO> buscarPorCRM(@RequestParam String crm){
+        MedicoDTO medicoDTO = mapper.toDTO(buscarMedico.buscarPorCPM(crm));
+        return ResponseEntity.ok(medicoDTO);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MedicoDTO>> listarTodos(){
+        List<MedicoDTO> medicos = buscarMedico.listarTodos().stream().map(mapper::toDTO).toList();
+        return ResponseEntity.ok(medicos);
+    }
+
+    @PostMapping
+    public ResponseEntity<MedicoDTO> criarMedico (@RequestBody MedicoDTO medicoDTO){
+        Medico medico = mapper.toDomain(medicoDTO);
+        medico = criarMedico.cadastrarMedico(medico);
+        MedicoDTO medicoCadastrado = mapper.toDTO(medico);
+        return ResponseEntity.status(HttpStatus.CREATED).body(medicoCadastrado);
+    }
+
+    @DeleteMapping("/medico")
+    public ResponseEntity<Void> deletarMedicoPorCRM(@RequestParam String crm){
+        deletarMedico.deletarPorCPF(crm);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaController.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaController.java
@@ -1,6 +1,7 @@
 package br.com.universus.gerenciador_reserva.adapter.controller;
 
 import br.com.universus.gerenciador_reserva.adapter.dto.reserva.ReservaDTO;
+import br.com.universus.gerenciador_reserva.adapter.dto.utils.HorariosDisponiveisPorDiaDTO;
 import br.com.universus.gerenciador_reserva.adapter.mapper.ReservaMapper;
 import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.BuscarReservaUsecase;
@@ -30,12 +31,20 @@ public class ReservaController {
     private final ReservaMapper mapper;
 
     @GetMapping("/proximas-datas-disponiveis")
-    public ResponseEntity<List<List<LocalDateTime>>> buscarProximosHorariosDisponiveis(
+    public ResponseEntity<List<HorariosDisponiveisPorDiaDTO>> buscarProximosHorariosDisponiveis(
             @RequestParam String crmMedico,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicial){
 
-        return ResponseEntity.ok(buscarReserva
-                .buscarProximosHorariosDisponiveis(crmMedico, dataInicial));
+
+        List<List<LocalDateTime>> horarios = buscarReserva.buscarProximosHorariosDisponiveis(crmMedico, dataInicial);
+
+        List<HorariosDisponiveisPorDiaDTO> resposta = horarios
+                .stream()
+                .map(lista -> new HorariosDisponiveisPorDiaDTO(lista.getFirst().toLocalDate(),
+                        lista.stream().map(LocalDateTime::toLocalTime).toList()))
+                .toList();
+
+        return ResponseEntity.ok(resposta);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaController.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaController.java
@@ -1,9 +1,12 @@
 package br.com.universus.gerenciador_reserva.adapter.controller;
 
-import br.com.universus.gerenciador_reserva.adapter.dto.ReservaDTO;
+import br.com.universus.gerenciador_reserva.adapter.dto.reserva.ReservaDTO;
 import br.com.universus.gerenciador_reserva.adapter.mapper.ReservaMapper;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.BuscarReservaUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.CriarReservaUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.reserva.DeletarReservaUsecase;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
 import br.com.universus.gerenciador_reserva.domain.models.Reserva;
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -22,23 +25,38 @@ public class ReservaController {
 
     private final BuscarReservaUsecase buscarReserva;
     private final CriarReservaUsecase criarReserva;
+    private final DeletarReservaUsecase deletarReserva;
+    private final BuscarMedicoUsecase buscarMedico;
     private final ReservaMapper mapper;
 
     @GetMapping("/proximas-datas-disponiveis")
     public ResponseEntity<List<List<LocalDateTime>>> buscarProximosHorariosDisponiveis(
-            @RequestParam String nomeMedico,
+            @RequestParam String crmMedico,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicial){
 
         return ResponseEntity.ok(buscarReserva
-                .buscarProximosHorariosDisponiveis(nomeMedico, dataInicial));
+                .buscarProximosHorariosDisponiveis(crmMedico, dataInicial));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ReservaDTO> buscarPorId(@PathVariable Long id){
+        ReservaDTO reservaDTO = mapper.toDTO(buscarReserva.buscarPorId(id));
+        return ResponseEntity.ok(reservaDTO);
     }
 
     @PostMapping
     public ResponseEntity<ReservaDTO> criarReserva (@RequestBody ReservaDTO reservaDTO){
-        Reserva reserva = mapper.toDomain(reservaDTO);
+        Medico medico = buscarMedico.buscarPorCPM(reservaDTO.crmMedico());
+        Reserva reserva = mapper.toDomain(reservaDTO, medico);
         reserva = criarReserva.cadastrarReserva(reserva);
         ReservaDTO reservaCadastrado = mapper.toDTO(reserva);
         return ResponseEntity.status(HttpStatus.CREATED).body(reservaCadastrado);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletarPorId(@PathVariable Long id){
+        deletarReserva.deletarPorId(id);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
     
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/controller/exception/GlobalExceptionHandler.java
@@ -1,8 +1,6 @@
 package br.com.universus.gerenciador_reserva.adapter.controller.exception;
 
-import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoDiaException;
-import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoHorarioException;
-import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaIndisponivelException;
+import br.com.universus.gerenciador_reserva.infra.exceptions.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -37,5 +35,21 @@ public class GlobalExceptionHandler {
         errorDetails.put("timestamp", LocalDateTime.now());
         errorDetails.put("mensagem", exception.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDetails);
+    }
+
+    @ExceptionHandler(CRMForaDoPadraoException.class)
+    public ResponseEntity<Map<String,Object>> cRMForaDoPadraoExceptionHandler (CRMForaDoPadraoException exception){
+        Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put("timestamp", LocalDateTime.now());
+        errorDetails.put("mensagem", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDetails);
+    }
+
+    @ExceptionHandler(RecursoNaoEncontradoException.class)
+    public ResponseEntity<Map<String,Object>> recursoNaoEncontradoExceptionHandler (RecursoNaoEncontradoException exception){
+        Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put("timestamp", LocalDateTime.now());
+        errorDetails.put("mensagem", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorDetails);
     }
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/dto/medico/MedicoDTO.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/dto/medico/MedicoDTO.java
@@ -1,0 +1,8 @@
+package br.com.universus.gerenciador_reserva.adapter.dto.medico;
+
+
+public record MedicoDTO(
+        String crm,
+        String nome
+        ) {
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/dto/reserva/ReservaDTO.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/dto/reserva/ReservaDTO.java
@@ -1,11 +1,11 @@
-package br.com.universus.gerenciador_reserva.adapter.dto;
+package br.com.universus.gerenciador_reserva.adapter.dto.reserva;
 
 import java.time.LocalDateTime;
 
 public record ReservaDTO(
         Long id,
         String nomePaciente,
-        String nomeMedico,
+        String crmMedico,
         LocalDateTime dataReserva
 ) {
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/dto/utils/HorariosDisponiveisPorDiaDTO.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/dto/utils/HorariosDisponiveisPorDiaDTO.java
@@ -1,0 +1,11 @@
+package br.com.universus.gerenciador_reserva.adapter.dto.utils;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record HorariosDisponiveisPorDiaDTO(
+        LocalDate data,
+        List<LocalTime> horarios
+) {
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/mapper/MedicoMapper.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/mapper/MedicoMapper.java
@@ -1,0 +1,35 @@
+package br.com.universus.gerenciador_reserva.adapter.mapper;
+
+import br.com.universus.gerenciador_reserva.adapter.dto.medico.MedicoDTO;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MedicoMapper {
+
+    public MedicoDTO toDTO(Medico medico) {
+        return new MedicoDTO(medico.getCrm(),
+                medico.getNome());
+    }
+
+    public Medico toDomain(MedicoDTO dto) {
+        return new Medico(
+                dto.crm(),
+                dto.nome()
+        );
+    }
+
+    public MedicoEntity toEntity(Medico medico) {
+        return new MedicoEntity(medico.getCrm(),
+                medico.getNome());
+    }
+
+    public Medico toDomain(MedicoEntity entity) {
+        return new Medico(
+                entity.getCrm(),
+                entity.getNome());
+    }
+
+
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/adapter/mapper/ReservaMapper.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/adapter/mapper/ReservaMapper.java
@@ -1,6 +1,7 @@
 package br.com.universus.gerenciador_reserva.adapter.mapper;
 
-import br.com.universus.gerenciador_reserva.adapter.dto.ReservaDTO;
+import br.com.universus.gerenciador_reserva.adapter.dto.reserva.ReservaDTO;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
 import br.com.universus.gerenciador_reserva.domain.models.Reserva;
 import br.com.universus.gerenciador_reserva.infra.persistence.entities.ReservaEntity;
 import org.springframework.stereotype.Component;
@@ -9,24 +10,30 @@ import org.springframework.stereotype.Component;
 public class ReservaMapper {
 
 
+    private final MedicoMapper medicoMapper;
+
+    public ReservaMapper(MedicoMapper medicoMapper) {
+        this.medicoMapper = medicoMapper;
+    }
+
     public ReservaDTO toDTO(Reserva reserva) {
         return new ReservaDTO(reserva.getId(),
                 reserva.getNomePaciente(),
-                reserva.getNomeMedico(),
+                reserva.getMedico().getCrm(),
                 reserva.getDataReserva());
     }
 
-    public Reserva toDomain(ReservaDTO dto) {
+    public Reserva toDomain(ReservaDTO dto, Medico medico) {
         return new Reserva(dto.id(),
                 dto.nomePaciente(),
-                dto.nomeMedico(),
+                medico,
                 dto.dataReserva());
     }
 
     public ReservaEntity toEntity(Reserva reserva) {
         ReservaEntity entity = new ReservaEntity();
         entity.setNomePaciente(reserva.getNomePaciente());
-        entity.setNomeMedico(reserva.getNomeMedico());
+        entity.setMedico(medicoMapper.toEntity(reserva.getMedico()));
         entity.setDataReserva(reserva.getDataReserva());
         return entity;
     }
@@ -34,7 +41,7 @@ public class ReservaMapper {
     public Reserva toDomain(ReservaEntity entity) {
         return new Reserva(entity.getId(),
                 entity.getNomePaciente(),
-                entity.getNomeMedico(),
+                medicoMapper.toDomain(entity.getMedico()),
                 entity.getDataReserva()
         );
     }

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/gateways/MedicoRepository.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/gateways/MedicoRepository.java
@@ -1,0 +1,18 @@
+package br.com.universus.gerenciador_reserva.application.gateways;
+
+
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MedicoRepository {
+    
+    Medico cadastrarMedico(Medico medico);
+    
+    Optional<Medico> buscarPorCRM(String crm);
+    
+    List<Medico> listarTodos();
+    
+    void deletarPorCRM(String crm);
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/gateways/ReservaRepository.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/gateways/ReservaRepository.java
@@ -1,5 +1,6 @@
 package br.com.universus.gerenciador_reserva.application.gateways;
 
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
 import br.com.universus.gerenciador_reserva.domain.models.Reserva;
 
 import java.time.LocalDate;
@@ -12,8 +13,12 @@ public interface ReservaRepository {
 
     Reserva cadastrarReserva(Reserva reserva);
 
-    List<LocalDateTime> buscaReservasPorMedicoEData(String nomeMedico, LocalDate dataReserva);
+    Optional<Reserva> buscarPorId(Long id);
 
-    Optional<Reserva> buscarReservaExistente(String nomeMedico, LocalDateTime dataReserva);
+    List<LocalDateTime> buscaReservasPorMedicoEData(Medico medico, LocalDate dataReserva);
+
+    Optional<Reserva> buscarReservaExistente(Medico medico, LocalDateTime dataReserva);
+
+    void deletarPorId(Long id);
 
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/medico/BuscarMedicoUsecase.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/medico/BuscarMedicoUsecase.java
@@ -1,0 +1,27 @@
+package br.com.universus.gerenciador_reserva.application.usecases.medico;
+
+
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.exceptions.RecursoNaoEncontradoException;
+
+import java.util.List;
+
+public class BuscarMedicoUsecase {
+
+    private final MedicoRepository repository;
+
+    public BuscarMedicoUsecase(MedicoRepository repository) {
+        this.repository = repository;
+    }
+
+    public Medico buscarPorCPM(String crm){
+        return repository.buscarPorCRM(crm).orElseThrow(() -> new RecursoNaoEncontradoException(
+                "Medico não encontrado com CRM: " + crm
+        ));
+    }
+
+    public List<Medico> listarTodos(){
+        return repository.listarTodos();
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/medico/CriarMedicoUsecase.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/medico/CriarMedicoUsecase.java
@@ -1,0 +1,19 @@
+package br.com.universus.gerenciador_reserva.application.usecases.medico;
+
+
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+
+public class CriarMedicoUsecase {
+
+    private final MedicoRepository repository;
+
+    public CriarMedicoUsecase(MedicoRepository repository) {
+        this.repository = repository;
+    }
+
+    public Medico cadastrarMedico(Medico enfermeiro){
+        return repository.cadastrarMedico(enfermeiro);
+    }
+
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/medico/DeletarMedicoUsecase.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/medico/DeletarMedicoUsecase.java
@@ -1,0 +1,17 @@
+package br.com.universus.gerenciador_reserva.application.usecases.medico;
+
+
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+
+public class DeletarMedicoUsecase {
+
+    private final MedicoRepository repository;
+
+    public DeletarMedicoUsecase(MedicoRepository repository) {
+        this.repository = repository;
+    }
+
+    public void deletarPorCPF(String cpf){
+        repository.deletarPorCRM(cpf);
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/BuscarReservaUsecase.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/BuscarReservaUsecase.java
@@ -1,6 +1,10 @@
 package br.com.universus.gerenciador_reserva.application.usecases.reserva;
 
 import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.domain.models.Reserva;
+import br.com.universus.gerenciador_reserva.infra.exceptions.RecursoNaoEncontradoException;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -10,13 +14,23 @@ import java.util.List;
 
 public class BuscarReservaUsecase {
 
-    private  final ReservaRepository repository;
+    private final ReservaRepository repository;
+    private final BuscarMedicoUsecase buscarMedico;
 
-    public BuscarReservaUsecase(ReservaRepository repository) {
+    public BuscarReservaUsecase(ReservaRepository repository, BuscarMedicoUsecase buscarMedico) {
         this.repository = repository;
+        this.buscarMedico = buscarMedico;
     }
 
-    public List<List<LocalDateTime>> buscarProximosHorariosDisponiveis(String nomeMedico, LocalDate dataInicial) {
+    public Reserva buscarPorId(Long id){
+        return repository.buscarPorId(id).orElseThrow(() -> new RecursoNaoEncontradoException(
+                "Reserva não encontrada com id: " + id
+        ));
+    }
+
+    public List<List<LocalDateTime>> buscarProximosHorariosDisponiveis(String crm, LocalDate dataInicial) {
+
+        Medico medico = buscarMedico.buscarPorCPM(crm);
 
         List<List<LocalDateTime>> proximasDatasEHorariosDisponiveis = new ArrayList<>();
 
@@ -26,7 +40,7 @@ public class BuscarReservaUsecase {
             if (data.getDayOfWeek() == DayOfWeek.MONDAY) {
 
                 List<LocalDateTime> horariosReservados = repository
-                        .buscaReservasPorMedicoEData(nomeMedico, data);
+                        .buscaReservasPorMedicoEData(medico, data);
 
                 List<LocalDateTime> horariosDoDia = gerarHorariosValidos(data);
 

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/CriarReservaUsecase.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/CriarReservaUsecase.java
@@ -1,6 +1,7 @@
 package br.com.universus.gerenciador_reserva.application.usecases.reserva;
 
 import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
 import br.com.universus.gerenciador_reserva.domain.models.Reserva;
 import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaIndisponivelException;
 
@@ -9,19 +10,22 @@ import java.util.Optional;
 public class CriarReservaUsecase {
 
     private final ReservaRepository repository;
+    private final BuscarMedicoUsecase buscarMedicoUseCase;
 
-    public CriarReservaUsecase(ReservaRepository repository) {
+    public CriarReservaUsecase(ReservaRepository repository, BuscarMedicoUsecase buscarMedicoUseCase) {
         this.repository = repository;
+        this.buscarMedicoUseCase = buscarMedicoUseCase;
     }
 
 
     public Reserva cadastrarReserva (Reserva reserva){
+        buscarMedicoUseCase.buscarPorCPM(reserva.getMedico().getCrm());
         verificarDisponibilidade(reserva);
         return repository.cadastrarReserva(reserva);
     }
 
     private void verificarDisponibilidade (Reserva reserva){
-        Optional<Reserva> reservaExistente = repository.buscarReservaExistente(reserva.getNomeMedico(),
+        Optional<Reserva> reservaExistente = repository.buscarReservaExistente(reserva.getMedico(),
                 reserva.getDataReserva());
 
         if (reservaExistente.isPresent()) {

--- a/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/DeletarReservaUsecase.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/DeletarReservaUsecase.java
@@ -1,0 +1,20 @@
+package br.com.universus.gerenciador_reserva.application.usecases.reserva;
+
+
+import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
+
+public class DeletarReservaUsecase {
+
+    private final ReservaRepository repository;
+    private final BuscarReservaUsecase buscarReserva;
+
+    public DeletarReservaUsecase(ReservaRepository repository, BuscarReservaUsecase buscarReserva) {
+        this.repository = repository;
+        this.buscarReserva = buscarReserva;
+    }
+
+    public void deletarPorId(Long id){
+        buscarReserva.buscarPorId(id);
+        repository.deletarPorId(id);
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/domain/models/Medico.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/domain/models/Medico.java
@@ -38,7 +38,7 @@ public class Medico {
         String crmLimpo = crm.trim();
         if (!crmLimpo.matches("^\\d{5}-\\d/[A-Z]{2}$")) {
             throw new CRMForaDoPadraoException("CRM fora do padrão. " +
-                    "Formato esperado: XXXXXX/UF (e.g., 12345-6/SP)");
+                    "Formato esperado: XXXXX-X/UF (e.g., 12345-6/SP)");
         }
     }
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/domain/models/Medico.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/domain/models/Medico.java
@@ -1,0 +1,44 @@
+package br.com.universus.gerenciador_reserva.domain.models;
+
+import br.com.universus.gerenciador_reserva.infra.exceptions.CRMForaDoPadraoException;
+
+public class Medico {
+
+    private String crm;
+    private String nome;
+
+    public Medico(String crm, String nome) {
+        validarCRM(crm);
+
+        this.crm = crm;
+        this.nome = nome;
+    }
+
+    public String getCrm() {
+        return crm;
+    }
+
+    public void setCrm(String crm) {
+        this.crm = crm;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    private void validarCRM(String crm) {
+        if (crm == null || crm.trim().isEmpty()) {
+            throw new CRMForaDoPadraoException("CRM não pode ser nulo ou vazio!");
+        }
+
+        String crmLimpo = crm.trim();
+        if (!crmLimpo.matches("^\\d{5}-\\d/[A-Z]{2}$")) {
+            throw new CRMForaDoPadraoException("CRM fora do padrão. " +
+                    "Formato esperado: XXXXXX/UF (e.g., 12345-6/SP)");
+        }
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/domain/models/Reserva.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/domain/models/Reserva.java
@@ -12,14 +12,14 @@ public class Reserva {
 
     private Long id;
     private String nomePaciente;
-    private String nomeMedico;
+    private Medico medico;
     private LocalDateTime dataReserva;
 
-    public Reserva(Long id, String nomePaciente, String nomeMedico, LocalDateTime dataReserva) {
+    public Reserva(Long id, String nomePaciente, Medico medico, LocalDateTime dataReserva) {
         validarHorario(dataReserva);
         this.id = id;
         this.nomePaciente = Objects.requireNonNull(nomePaciente);
-        this.nomeMedico = Objects.requireNonNull(nomeMedico);
+        this.medico = Objects.requireNonNull(medico);
         this.dataReserva = Objects.requireNonNull(dataReserva);
     }
 
@@ -43,6 +43,6 @@ public class Reserva {
     // Getters
     public Long getId() { return id; }
     public String getNomePaciente() { return nomePaciente; }
-    public String getNomeMedico() { return nomeMedico; }
+    public Medico getMedico() { return medico; }
     public LocalDateTime getDataReserva() { return dataReserva; }
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/config/MedicoConfig.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/config/MedicoConfig.java
@@ -1,0 +1,36 @@
+package br.com.universus.gerenciador_reserva.infra.config;
+
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.CriarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.DeletarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.infra.persistence.gateways.MedicoRepositoryJPAImpl;
+import br.com.universus.gerenciador_reserva.infra.persistence.repository.MedicoRepositoryJPA;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MedicoConfig {
+    
+    @Bean
+    BuscarMedicoUsecase buscarMedicoUseCase(MedicoRepository repository){
+        return new BuscarMedicoUsecase(repository);
+    }
+
+    @Bean
+    CriarMedicoUsecase criarMedicoUseCase(MedicoRepository repository){
+        return new CriarMedicoUsecase(repository);
+    }
+
+    @Bean
+    DeletarMedicoUsecase deletarMedicoUseCase(MedicoRepository repository){
+        return new DeletarMedicoUsecase(repository);
+    }
+
+    @Bean
+    MedicoRepositoryJPAImpl criarImplementacaoMedicoRepositoryJPA(MedicoRepositoryJPA repositoryJPA,
+                                                                  MedicoMapper mapper){
+        return new MedicoRepositoryJPAImpl(repositoryJPA, mapper);
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/config/ReservaConfig.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/config/ReservaConfig.java
@@ -1,9 +1,12 @@
 package br.com.universus.gerenciador_reserva.infra.config;
 
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
 import br.com.universus.gerenciador_reserva.adapter.mapper.ReservaMapper;
 import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.BuscarReservaUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.CriarReservaUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.reserva.DeletarReservaUsecase;
 import br.com.universus.gerenciador_reserva.infra.persistence.gateways.ReservaRepositoryJPAImpl;
 import br.com.universus.gerenciador_reserva.infra.persistence.repository.ReservaRepositoryJPA;
 import org.springframework.context.annotation.Bean;
@@ -13,18 +16,26 @@ import org.springframework.context.annotation.Configuration;
 public class ReservaConfig {
 
     @Bean
-    BuscarReservaUsecase buscarReservaUsecase(ReservaRepository repository){
-        return new BuscarReservaUsecase(repository);
+    BuscarReservaUsecase buscarReservaUsecase(ReservaRepository repository, BuscarMedicoUsecase buscarMedico){
+        return new BuscarReservaUsecase(repository, buscarMedico);
     }
 
     @Bean
-    CriarReservaUsecase criarReservaUseCase(ReservaRepository repository){
-        return new CriarReservaUsecase(repository);
+    CriarReservaUsecase criarReservaUseCase(ReservaRepository repository, BuscarMedicoUsecase buscarMedicoUseCase){
+        return new CriarReservaUsecase(repository, buscarMedicoUseCase);
+    }
+
+    @Bean
+    DeletarReservaUsecase deletarReservaUsecase(ReservaRepository repository, BuscarReservaUsecase buscarReserva ){
+        return new DeletarReservaUsecase(repository, buscarReserva);
     }
 
     @Bean
     ReservaRepositoryJPAImpl criarImplementacaoReservaRepositoryJPA(ReservaRepositoryJPA repositoryJPA,
-                                                                    ReservaMapper mapper){
-        return new ReservaRepositoryJPAImpl(repositoryJPA, mapper);
+                                                                    ReservaMapper reservaMapper,
+                                                                    MedicoMapper medicoMapper){
+        return new ReservaRepositoryJPAImpl(repositoryJPA, reservaMapper, medicoMapper);
     }
+
+
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/exceptions/CRMForaDoPadraoException.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/exceptions/CRMForaDoPadraoException.java
@@ -1,0 +1,7 @@
+package br.com.universus.gerenciador_reserva.infra.exceptions;
+
+public class CRMForaDoPadraoException extends RuntimeException {
+    public CRMForaDoPadraoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/exceptions/RecursoNaoEncontradoException.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/exceptions/RecursoNaoEncontradoException.java
@@ -1,0 +1,7 @@
+package br.com.universus.gerenciador_reserva.infra.exceptions;
+
+public class RecursoNaoEncontradoException extends RuntimeException {
+  public RecursoNaoEncontradoException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/entities/MedicoEntity.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/entities/MedicoEntity.java
@@ -1,0 +1,19 @@
+package br.com.universus.gerenciador_reserva.infra.persistence.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="Medico")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class MedicoEntity {
+    @Id
+    private String crm;
+    private String nome;
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/entities/ReservaEntity.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/entities/ReservaEntity.java
@@ -18,8 +18,10 @@ public class ReservaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String nomePaciente;
-    private String nomeMedico;
-    private LocalDateTime dataReserva;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "crm_medico", referencedColumnName = "crm", nullable = false)
+    private MedicoEntity medico;
+    private LocalDateTime dataReserva;
 
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/gateways/MedicoRepositoryJPAImpl.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/gateways/MedicoRepositoryJPAImpl.java
@@ -1,0 +1,51 @@
+package br.com.universus.gerenciador_reserva.infra.persistence.gateways;
+
+
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.exceptions.RecursoNaoEncontradoException;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
+import br.com.universus.gerenciador_reserva.infra.persistence.repository.MedicoRepositoryJPA;
+
+import java.util.List;
+import java.util.Optional;
+
+public class MedicoRepositoryJPAImpl implements MedicoRepository {
+
+    private final MedicoRepositoryJPA repository;
+    private final MedicoMapper mapper;
+
+    public MedicoRepositoryJPAImpl(MedicoRepositoryJPA repository, MedicoMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+
+    @Override
+    public Medico cadastrarMedico(Medico medico) {
+        MedicoEntity medicoRecebido = mapper.toEntity(medico);
+        MedicoEntity medicoSalvo = repository.save(medicoRecebido);
+        return mapper.toDomain(medicoSalvo);
+    }
+
+    @Override
+    public Optional<Medico> buscarPorCRM(String crm) {
+        return repository.findById(crm)
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public List<Medico> listarTodos() {
+        return repository.findAll()
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void deletarPorCRM(String crm) {
+        this.buscarPorCRM(crm);
+        repository.deleteById(crm);
+    }
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/gateways/MedicoRepositoryJPAImpl.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/gateways/MedicoRepositoryJPAImpl.java
@@ -4,7 +4,6 @@ package br.com.universus.gerenciador_reserva.infra.persistence.gateways;
 import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
 import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
 import br.com.universus.gerenciador_reserva.domain.models.Medico;
-import br.com.universus.gerenciador_reserva.infra.exceptions.RecursoNaoEncontradoException;
 import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
 import br.com.universus.gerenciador_reserva.infra.persistence.repository.MedicoRepositoryJPA;
 

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/gateways/ReservaRepositoryJPAImpl.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/gateways/ReservaRepositoryJPAImpl.java
@@ -1,9 +1,12 @@
 package br.com.universus.gerenciador_reserva.infra.persistence.gateways;
 
 
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
 import br.com.universus.gerenciador_reserva.adapter.mapper.ReservaMapper;
 import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
 import br.com.universus.gerenciador_reserva.domain.models.Reserva;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
 import br.com.universus.gerenciador_reserva.infra.persistence.entities.ReservaEntity;
 import br.com.universus.gerenciador_reserva.infra.persistence.repository.ReservaRepositoryJPA;
 
@@ -15,30 +18,42 @@ import java.util.Optional;
 public class ReservaRepositoryJPAImpl implements ReservaRepository {
 
     private final ReservaRepositoryJPA repository;
-    private final ReservaMapper mapper;
+    private final ReservaMapper reservaMapper;
+    private final MedicoMapper medicoMapper;
 
-    public ReservaRepositoryJPAImpl(ReservaRepositoryJPA repository, ReservaMapper mapper) {
+    public ReservaRepositoryJPAImpl(ReservaRepositoryJPA repository, ReservaMapper mapper, MedicoMapper medicoMapper) {
         this.repository = repository;
-        this.mapper = mapper;
+        this.reservaMapper = mapper;
+        this.medicoMapper = medicoMapper;
     }
 
     @Override
     public Reserva cadastrarReserva(Reserva reserva) {
-        ReservaEntity reservaRecebido = mapper.toEntity(reserva);
+        ReservaEntity reservaRecebido = reservaMapper.toEntity(reserva);
         ReservaEntity reservaSalvo = repository.save(reservaRecebido);
-        return mapper.toDomain(reservaSalvo);
-    }
-
-
-
-    @Override
-    public List<LocalDateTime> buscaReservasPorMedicoEData(String nomeMedico, LocalDate dataReserva) {
-        return repository.findAllByNomeMedicoAndDataReserva(nomeMedico, dataReserva);
+        return reservaMapper.toDomain(reservaSalvo);
     }
 
     @Override
-    public Optional<Reserva> buscarReservaExistente(String nomeMedico, LocalDateTime dataReserva) {
-        return repository.findByNomeMedicoAndDataReserva(nomeMedico, dataReserva)
-                .map(mapper::toDomain);
+    public List<LocalDateTime> buscaReservasPorMedicoEData(Medico medico, LocalDate dataReserva) {
+        MedicoEntity medicoEntity = medicoMapper.toEntity(medico);
+        return repository.findAllByMedicoAndDataReserva(medicoEntity, dataReserva);
+    }
+
+    @Override
+    public Optional<Reserva> buscarPorId(Long id){
+        return repository.findById(id).map(reservaMapper::toDomain);
+    }
+
+    @Override
+    public Optional<Reserva> buscarReservaExistente(Medico medico, LocalDateTime dataReserva) {
+        MedicoEntity medicoEntity = medicoMapper.toEntity(medico);
+        return repository.findByMedicoAndDataReserva(medicoEntity, dataReserva)
+                .map(reservaMapper::toDomain);
+    }
+
+    @Override
+    public void deletarPorId(Long id) {
+        repository.deleteById(id);
     }
 }

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/repository/MedicoRepositoryJPA.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/repository/MedicoRepositoryJPA.java
@@ -1,0 +1,8 @@
+package br.com.universus.gerenciador_reserva.infra.persistence.repository;
+
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MedicoRepositoryJPA extends JpaRepository<MedicoEntity, String> {
+
+}

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/repository/ReservaRepositoryJPA.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/repository/ReservaRepositoryJPA.java
@@ -1,6 +1,5 @@
 package br.com.universus.gerenciador_reserva.infra.persistence.repository;
 
-import br.com.universus.gerenciador_reserva.domain.models.Medico;
 import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
 import br.com.universus.gerenciador_reserva.infra.persistence.entities.ReservaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/repository/ReservaRepositoryJPA.java
+++ b/src/main/java/br/com/universus/gerenciador_reserva/infra/persistence/repository/ReservaRepositoryJPA.java
@@ -1,5 +1,7 @@
 package br.com.universus.gerenciador_reserva.infra.persistence.repository;
 
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
 import br.com.universus.gerenciador_reserva.infra.persistence.entities.ReservaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,9 +14,9 @@ import java.util.Optional;
 public interface ReservaRepositoryJPA extends JpaRepository<ReservaEntity, Long> {
 
     @Query("SELECT r.dataReserva FROM ReservaEntity r " +
-            "WHERE r.nomeMedico = :nomeMedico " +
+            "WHERE r.medico = :medico " +
             "AND FUNCTION ('DATE', r.dataReserva) >= :dataReserva")
-    List<LocalDateTime> findAllByNomeMedicoAndDataReserva(String nomeMedico, LocalDate dataReserva);
+    List<LocalDateTime> findAllByMedicoAndDataReserva(MedicoEntity medico, LocalDate dataReserva);
 
-    Optional<ReservaEntity> findByNomeMedicoAndDataReserva(String nomeMedico, LocalDateTime dataReserva);
+    Optional<ReservaEntity> findByMedicoAndDataReserva(MedicoEntity medico, LocalDateTime dataReserva);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=universus-gerenciador-reserva
+spring.application.name=
 
 # PostgreSQL Database Configuration
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/universus-gerenciador-reserva}

--- a/src/main/resources/db/migration/V03__create_table_medico_and_populate.sql
+++ b/src/main/resources/db/migration/V03__create_table_medico_and_populate.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS Medico (
+    crm VARCHAR(50) PRIMARY KEY,
+    nome VARCHAR(100)
+);
+
+INSERT INTO Medico (crm, nome) VALUES
+('CRM-SP-123456', 'Dr. João Pedro Silva'),
+('CRM-RJ-654321', 'Dra. Angelica Costa'),
+('CRM-MG-789123', 'Dr. Carlos Mendes');

--- a/src/main/resources/db/migration/V04__alter_table_reserva_including_medico_fk.sql
+++ b/src/main/resources/db/migration/V04__alter_table_reserva_including_medico_fk.sql
@@ -1,0 +1,20 @@
+-- 1. Adicionar coluna crm_medico na tabela Reserva
+ALTER TABLE Reserva ADD COLUMN crm_medico VARCHAR(14);
+
+-- 2. Preencher crm_medico com base no nome parcial (ignorando "Dr./Dra." e usando ILIKE para ser case-insensitive)
+UPDATE Reserva r
+SET crm_medico = m.crm
+FROM Medico m
+WHERE m.nome ILIKE CONCAT('%', r.nome_medico, '%');
+
+-- 3. Tornar crm_medico obrigatório
+ALTER TABLE Reserva ALTER COLUMN crm_medico SET NOT NULL;
+
+-- 4. Criar a Foreign Key
+ALTER TABLE Reserva
+ADD CONSTRAINT fk_reserva_medico
+FOREIGN KEY (crm_medico)
+REFERENCES Medico(crm);
+
+-- 5. Remover a coluna nome_medico
+ALTER TABLE Reserva DROP COLUMN nome_medico;

--- a/src/main/resources/db/migration/V05__fix_crm_medicos.sql
+++ b/src/main/resources/db/migration/V05__fix_crm_medicos.sql
@@ -1,0 +1,23 @@
+
+INSERT INTO Medico (crm, nome) VALUES
+('12345-6/SP', 'Dr. João Pedro Silva'),
+('65432-1/RJ', 'Dra. Angelica Costa'),
+('78912-3/MG', 'Dr. Carlos Mendes');
+
+UPDATE Reserva
+SET crm_medico = '12345-6/SP'
+WHERE crm_medico = 'CRM-SP-123456';
+
+UPDATE Reserva
+SET crm_medico = '65432-1/RJ'
+WHERE crm_medico = 'CRM-RJ-654321';
+
+UPDATE Reserva
+SET crm_medico = '78912-3/MG'
+WHERE crm_medico = 'CRM-MG-789123';
+
+DELETE FROM Medico WHERE crm IN (
+  'CRM-SP-123456',
+  'CRM-RJ-654321',
+  'CRM-MG-789123'
+);

--- a/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/MedicoControllerTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/MedicoControllerTest.java
@@ -1,0 +1,107 @@
+package br.com.universus.gerenciador_reserva.adapter.controller;
+
+import br.com.universus.gerenciador_reserva.adapter.dto.medico.MedicoDTO;
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.CriarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.DeletarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedicoDto;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MedicoControllerTest {
+
+    @Mock
+    private BuscarMedicoUsecase buscarMedico;
+
+    @Mock
+    private CriarMedicoUsecase criarMedico;
+
+    @Mock
+    private DeletarMedicoUsecase deletarMedico;
+
+    @Mock
+    private MedicoMapper mapper;
+
+    private MedicoController controller;
+
+    private Medico medico;
+    private MedicoDTO medicoDTO;
+
+    @BeforeEach
+    void setup() {
+        controller = new MedicoController(buscarMedico, criarMedico, deletarMedico, mapper);
+        medico = gerarMedico();
+        medicoDTO = gerarMedicoDto(medico);
+    }
+
+    @Test
+    void deveBuscarMedicoPorCRM() {
+        String crm = medico.getCrm();
+        when(buscarMedico.buscarPorCPM(crm)).thenReturn(medico);
+        when(mapper.toDTO(medico)).thenReturn(medicoDTO);
+
+        ResponseEntity<MedicoDTO> response = controller.buscarPorCRM(crm);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(medicoDTO, response.getBody());
+        verify(buscarMedico).buscarPorCPM(crm);
+        verify(mapper).toDTO(medico);
+    }
+
+    @Test
+    void deveListarTodosMedicos() {
+        List<Medico> medicos = List.of(medico);
+        List<MedicoDTO> medicoDTOs = List.of(medicoDTO);
+
+        when(buscarMedico.listarTodos()).thenReturn(medicos);
+        when(mapper.toDTO(any(Medico.class))).thenReturn(medicoDTO);
+
+        ResponseEntity<List<MedicoDTO>> response = controller.listarTodos();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(medicoDTOs.size(), response.getBody().size());
+        verify(buscarMedico).listarTodos();
+        verify(mapper, times(medicos.size())).toDTO(any(Medico.class));
+    }
+
+    @Test
+    void deveCriarMedico() {
+        when(mapper.toDomain(medicoDTO)).thenReturn(medico);
+        when(criarMedico.cadastrarMedico(medico)).thenReturn(medico);
+        when(mapper.toDTO(medico)).thenReturn(medicoDTO);
+
+        ResponseEntity<MedicoDTO> response = controller.criarMedico(medicoDTO);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(medicoDTO, response.getBody());
+        verify(mapper).toDomain(medicoDTO);
+        verify(criarMedico).cadastrarMedico(medico);
+        verify(mapper).toDTO(medico);
+    }
+
+    @Test
+    void deveDeletarMedicoPorCRM() {
+        String crm = medico.getCrm();
+
+        ResponseEntity<Void> response = controller.deletarMedicoPorCRM(crm);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(deletarMedico).deletarPorCPF(crm);
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaControllerTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaControllerTest.java
@@ -1,10 +1,8 @@
 package br.com.universus.gerenciador_reserva.adapter.controller;
 
-import br.com.universus.gerenciador_reserva.adapter.dto.ReservaDTO;
 import br.com.universus.gerenciador_reserva.adapter.mapper.ReservaMapper;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.BuscarReservaUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.CriarReservaUsecase;
-import br.com.universus.gerenciador_reserva.domain.models.Reserva;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -64,24 +62,24 @@ class ReservaControllerTest {
     @Test
     void deveCriarReservaComSucesso() {
         // Arrange
-        ReservaDTO inputDto = new ReservaDTO(null, "Paciente", "Dr. João", LocalDateTime.of(2025, 7,21,16,0));
-        Reserva reservaDomain = new Reserva(1L, "Paciente", "Dr. João", LocalDateTime.of(2025, 7, 21, 16, 0));
-        ReservaDTO outputDto = new ReservaDTO(1L, "Paciente", "Dr. João", LocalDateTime.of(2025, 7,21,16,0));
-
-        when(mapper.toDomain(inputDto)).thenReturn(reservaDomain);
-        when(criarReserva.cadastrarReserva(reservaDomain)).thenReturn(reservaDomain);
-        when(mapper.toDTO(reservaDomain)).thenReturn(outputDto);
-
-        // Act
-        ResponseEntity<ReservaDTO> response = controller.criarReserva(inputDto);
-
-        // Assert
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(response.getBody()).isEqualTo(outputDto);
-
-        verify(mapper).toDomain(inputDto);
-        verify(criarReserva).cadastrarReserva(reservaDomain);
-        verify(mapper).toDTO(reservaDomain);
+//        ReservaDTO inputDto = new ReservaDTO(null, "Paciente", "Dr. João", LocalDateTime.of(2025, 7,21,16,0));
+//        Reserva reservaDomain = new Reserva(1L, "Paciente", "Dr. João", LocalDateTime.of(2025, 7, 21, 16, 0));
+//        ReservaDTO outputDto = new ReservaDTO(1L, "Paciente", "Dr. João", LocalDateTime.of(2025, 7,21,16,0));
+//
+//        when(mapper.toDomain(inputDto, )).thenReturn(reservaDomain);
+//        when(criarReserva.cadastrarReserva(reservaDomain)).thenReturn(reservaDomain);
+//        when(mapper.toDTO(reservaDomain)).thenReturn(outputDto);
+//
+//        // Act
+//        ResponseEntity<ReservaDTO> response = controller.criarReserva(inputDto);
+//
+//        // Assert
+//        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+//        assertThat(response.getBody()).isEqualTo(outputDto);
+//
+//        verify(mapper).toDomain(inputDto);
+//        verify(criarReserva).cadastrarReserva(reservaDomain);
+//        verify(mapper).toDTO(reservaDomain);
     }
 
 }

--- a/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaControllerTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/ReservaControllerTest.java
@@ -1,11 +1,17 @@
 package br.com.universus.gerenciador_reserva.adapter.controller;
 
+import br.com.universus.gerenciador_reserva.adapter.dto.reserva.ReservaDTO;
+import br.com.universus.gerenciador_reserva.adapter.dto.utils.HorariosDisponiveisPorDiaDTO;
 import br.com.universus.gerenciador_reserva.adapter.mapper.ReservaMapper;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.BuscarReservaUsecase;
 import br.com.universus.gerenciador_reserva.application.usecases.reserva.CriarReservaUsecase;
+import br.com.universus.gerenciador_reserva.application.usecases.reserva.DeletarReservaUsecase;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.domain.models.Reserva;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -15,15 +21,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
+import static br.com.universus.gerenciador_reserva.utils.ReservaHelper.gerarReserva;
+import static br.com.universus.gerenciador_reserva.utils.ReservaHelper.gerarReservaDto;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ReservaControllerTest {
-
-    @InjectMocks
-    private ReservaController controller;
 
     @Mock
     private BuscarReservaUsecase buscarReserva;
@@ -32,55 +38,87 @@ class ReservaControllerTest {
     private CriarReservaUsecase criarReserva;
 
     @Mock
+    private DeletarReservaUsecase deletarReserva;
+
+    @Mock
+    private BuscarMedicoUsecase buscarMedico;
+
+    @Mock
     private ReservaMapper mapper;
+
+    private ReservaController controller;
+
+    private Reserva reserva;
+    private ReservaDTO reservaDTO;
+    private Medico medico;
+
+    @BeforeEach
+    void setup() {
+        controller = new ReservaController(buscarReserva, criarReserva, deletarReserva, buscarMedico, mapper);
+        medico = gerarMedico();
+        reserva = gerarReserva();
+        reservaDTO = gerarReservaDto(reserva);
+    }
 
     @Test
     void deveBuscarProximosHorariosDisponiveis() {
-        // Arrange
-        String nomeMedico = "Dr. João";
-        LocalDate data = LocalDate.of(2025, 7, 21);
+        String crmMedico = medico.getCrm();
+        LocalDate dataInicial = LocalDate.now();
+
         List<List<LocalDateTime>> horarios = List.of(
-                List.of(
-                        LocalDateTime.of(2025, 7, 21, 16, 0),
-                        LocalDateTime.of(2025, 7, 21, 16, 30)
-                )
+                List.of(LocalDateTime.of(2025,7,21,16,30), LocalDateTime.of(2025,7,21,17,30))
         );
 
-        when(buscarReserva.buscarProximosHorariosDisponiveis(nomeMedico, data)).thenReturn(horarios);
+        when(buscarReserva.buscarProximosHorariosDisponiveis(crmMedico, dataInicial)).thenReturn(horarios);
 
-        // Act
-        ResponseEntity<List<List<LocalDateTime>>> response = controller
-                .buscarProximosHorariosDisponiveis(nomeMedico, data);
+        ResponseEntity<List<HorariosDisponiveisPorDiaDTO>> response = controller.buscarProximosHorariosDisponiveis(crmMedico, dataInicial);
 
-        // Assert
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isEqualTo(horarios);
-
-        verify(buscarReserva).buscarProximosHorariosDisponiveis(nomeMedico, data);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertFalse(response.getBody().isEmpty());
+        assertEquals(horarios.get(0).get(0).toLocalDate(), response.getBody().get(0).data());
     }
 
     @Test
-    void deveCriarReservaComSucesso() {
-        // Arrange
-//        ReservaDTO inputDto = new ReservaDTO(null, "Paciente", "Dr. João", LocalDateTime.of(2025, 7,21,16,0));
-//        Reserva reservaDomain = new Reserva(1L, "Paciente", "Dr. João", LocalDateTime.of(2025, 7, 21, 16, 0));
-//        ReservaDTO outputDto = new ReservaDTO(1L, "Paciente", "Dr. João", LocalDateTime.of(2025, 7,21,16,0));
-//
-//        when(mapper.toDomain(inputDto, )).thenReturn(reservaDomain);
-//        when(criarReserva.cadastrarReserva(reservaDomain)).thenReturn(reservaDomain);
-//        when(mapper.toDTO(reservaDomain)).thenReturn(outputDto);
-//
-//        // Act
-//        ResponseEntity<ReservaDTO> response = controller.criarReserva(inputDto);
-//
-//        // Assert
-//        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-//        assertThat(response.getBody()).isEqualTo(outputDto);
-//
-//        verify(mapper).toDomain(inputDto);
-//        verify(criarReserva).cadastrarReserva(reservaDomain);
-//        verify(mapper).toDTO(reservaDomain);
+    void deveBuscarReservaPorId() {
+        Long id = reserva.getId();
+
+        when(buscarReserva.buscarPorId(id)).thenReturn(reserva);
+        when(mapper.toDTO(reserva)).thenReturn(reservaDTO);
+
+        ResponseEntity<ReservaDTO> response = controller.buscarPorId(id);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(reservaDTO, response.getBody());
+        verify(buscarReserva).buscarPorId(id);
+        verify(mapper).toDTO(reserva);
     }
 
+    @Test
+    void deveCriarReserva() {
+        when(buscarMedico.buscarPorCPM(reservaDTO.crmMedico())).thenReturn(medico);
+        when(mapper.toDomain(reservaDTO, medico)).thenReturn(reserva);
+        when(criarReserva.cadastrarReserva(reserva)).thenReturn(reserva);
+        when(mapper.toDTO(reserva)).thenReturn(reservaDTO);
+
+        ResponseEntity<ReservaDTO> response = controller.criarReserva(reservaDTO);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(reservaDTO, response.getBody());
+        verify(buscarMedico).buscarPorCPM(reservaDTO.crmMedico());
+        verify(mapper).toDomain(reservaDTO, medico);
+        verify(criarReserva).cadastrarReserva(reserva);
+        verify(mapper).toDTO(reserva);
+    }
+
+    @Test
+    void deveDeletarReservaPorId() {
+        Long id = reserva.getId();
+
+        ResponseEntity<Void> response = controller.deletarPorId(id);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(deletarReserva).deletarPorId(id);
+    }
 }
+
 

--- a/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/exception/ExcecaoFakeController.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/exception/ExcecaoFakeController.java
@@ -1,0 +1,37 @@
+package br.com.universus.gerenciador_reserva.adapter.controller.exception;
+
+import br.com.universus.gerenciador_reserva.infra.exceptions.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/fake")
+class ExcecaoFakeController {
+
+    @GetMapping("/reserva-fora-do-horario")
+    public void reservaForaDoHorario() {
+        throw new ReservaForaDoHorarioException("Horário inválido");
+    }
+
+    @GetMapping("/reserva-fora-do-dia")
+    public void reservaForaDoDia() {
+        throw new ReservaForaDoDiaException("Dia inválido");
+    }
+
+    @GetMapping("/reserva-indisponivel")
+    public void reservaIndisponivel() {
+        throw new ReservaIndisponivelException("Horário não disponível");
+    }
+
+    @GetMapping("/crm-invalido")
+    public void crmInvalido() {
+        throw new CRMForaDoPadraoException("CRM inválido");
+    }
+
+    @GetMapping("/recurso-nao-encontrado")
+    public void recursoNaoEncontrado() {
+        throw new RecursoNaoEncontradoException("Recurso não encontrado");
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/adapter/controller/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,53 @@
+package br.com.universus.gerenciador_reserva.adapter.controller.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ExcecaoFakeController.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void deveTratarReservaForaDoHorarioException() throws Exception {
+        mockMvc.perform(get("/fake/reserva-fora-do-horario"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensagem").value("Horário inválido"));
+    }
+
+    @Test
+    void deveTratarReservaForaDoDiaException() throws Exception {
+        mockMvc.perform(get("/fake/reserva-fora-do-dia"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensagem").value("Dia inválido"));
+    }
+
+    @Test
+    void deveTratarReservaIndisponivelException() throws Exception {
+        mockMvc.perform(get("/fake/reserva-indisponivel"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensagem").value("Horário não disponível"));
+    }
+
+    @Test
+    void deveTratarCRMForaDoPadraoException() throws Exception {
+        mockMvc.perform(get("/fake/crm-invalido"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensagem").value("CRM inválido"));
+    }
+
+    @Test
+    void deveTratarRecursoNaoEncontradoException() throws Exception {
+        mockMvc.perform(get("/fake/recurso-nao-encontrado"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.mensagem").value("Recurso não encontrado"));
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/adapter/mapper/MedicoMapperTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/adapter/mapper/MedicoMapperTest.java
@@ -1,0 +1,58 @@
+package br.com.universus.gerenciador_reserva.adapter.mapper;
+
+import br.com.universus.gerenciador_reserva.adapter.dto.medico.MedicoDTO;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MedicoMapperTest {
+
+    private MedicoMapper mapper;
+    private Medico medico;
+
+    @BeforeEach
+    void setup() {
+        mapper = new MedicoMapper();
+        medico = gerarMedico();
+    }
+
+    @Test
+    void deveConverterDeDomainParaDTO() {
+        MedicoDTO dto = mapper.toDTO(medico);
+
+        assertEquals(medico.getCrm(), dto.crm());
+        assertEquals(medico.getNome(), dto.nome());
+    }
+
+    @Test
+    void deveConverterDeDTOParaDomain() {
+        MedicoDTO dto = gerarMedicoDto(medico);
+
+        Medico convertido = mapper.toDomain(dto);
+
+        assertEquals(dto.crm(), convertido.getCrm());
+        assertEquals(dto.nome(), convertido.getNome());
+    }
+
+    @Test
+    void deveConverterDeDomainParaEntity() {
+        MedicoEntity entity = mapper.toEntity(medico);
+
+        assertEquals(medico.getCrm(), entity.getCrm());
+        assertEquals(medico.getNome(), entity.getNome());
+    }
+
+    @Test
+    void deveConverterDeEntityParaDomain() {
+        MedicoEntity entity = gerarMedicoEntity(medico);
+
+        Medico convertido = mapper.toDomain(entity);
+
+        assertEquals(entity.getCrm(), convertido.getCrm());
+        assertEquals(entity.getNome(), convertido.getNome());
+    }
+}

--- a/src/test/java/br/com/universus/gerenciador_reserva/adapter/mapper/ReservaMapperTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/adapter/mapper/ReservaMapperTest.java
@@ -1,0 +1,73 @@
+package br.com.universus.gerenciador_reserva.adapter.mapper;
+
+
+import br.com.universus.gerenciador_reserva.adapter.dto.reserva.ReservaDTO;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.domain.models.Reserva;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.ReservaEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
+import static br.com.universus.gerenciador_reserva.utils.ReservaHelper.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReservaMapperTest {
+
+    private MedicoMapper medicoMapper;
+    private ReservaMapper reservaMapper;
+    private Reserva reserva;
+    private Medico medico;
+
+    @BeforeEach
+    void setup() {
+        medicoMapper = new MedicoMapper();
+        reservaMapper = new ReservaMapper(medicoMapper);
+        medico = gerarMedico();
+        reserva = gerarReserva();
+    }
+
+    @Test
+    void deveConverterDeDomainParaDTO() {
+        ReservaDTO dto = reservaMapper.toDTO(reserva);
+
+        assertEquals(reserva.getId(), dto.id());
+        assertEquals(reserva.getNomePaciente(), dto.nomePaciente());
+        assertEquals(reserva.getMedico().getCrm(), dto.crmMedico());
+        assertEquals(reserva.getDataReserva(), dto.dataReserva());
+    }
+
+    @Test
+    void deveConverterDeDTOParaDomain() {
+        ReservaDTO dto = gerarReservaDto(reserva);
+
+        Reserva convertido = reservaMapper.toDomain(dto, medico);
+
+        assertEquals(dto.id(), convertido.getId());
+        assertEquals(dto.nomePaciente(), convertido.getNomePaciente());
+        assertEquals(dto.dataReserva(), convertido.getDataReserva());
+        assertEquals(medico.getCrm(), convertido.getMedico().getCrm());
+    }
+
+    @Test
+    void deveConverterDeDomainParaEntity() {
+        ReservaEntity entity = reservaMapper.toEntity(reserva);
+
+        assertEquals(reserva.getNomePaciente(), entity.getNomePaciente());
+        assertEquals(reserva.getDataReserva(), entity.getDataReserva());
+        assertEquals(reserva.getMedico().getCrm(), entity.getMedico().getCrm());
+    }
+
+    @Test
+    void deveConverterDeEntityParaDomain() {
+        ReservaEntity entity = gerarReservaEntity(reserva);
+
+        Reserva convertido = reservaMapper.toDomain(entity);
+
+        assertEquals(entity.getId(), convertido.getId());
+        assertEquals(entity.getNomePaciente(), convertido.getNomePaciente());
+        assertEquals(entity.getDataReserva(), convertido.getDataReserva());
+        assertEquals(entity.getMedico().getCrm(), convertido.getMedico().getCrm());
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/medico/BuscarMedicoUsecaseTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/medico/BuscarMedicoUsecaseTest.java
@@ -1,0 +1,67 @@
+package br.com.universus.gerenciador_reserva.application.usecases.medico;
+
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.exceptions.RecursoNaoEncontradoException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BuscarMedicoUsecaseTest {
+
+    @Mock
+    private MedicoRepository repository;
+
+    private BuscarMedicoUsecase buscarMedicoUsecase;
+
+    private Medico medico;
+
+    @BeforeEach
+    void setup() {
+        buscarMedicoUsecase = new BuscarMedicoUsecase(repository);
+        medico = gerarMedico();
+    }
+
+    @Test
+    void deveBuscarMedicoPorCrmComSucesso() {
+        when(repository.buscarPorCRM(medico.getCrm())).thenReturn(Optional.of(medico));
+
+        Medico resultado = buscarMedicoUsecase.buscarPorCPM(medico.getCrm());
+
+        assertEquals(medico, resultado);
+        verify(repository).buscarPorCRM(medico.getCrm());
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoNaoEncontrarMedico() {
+        String crmInvalido = "00000-0/XX";
+        when(repository.buscarPorCRM(crmInvalido)).thenReturn(Optional.empty());
+
+        assertThrows(RecursoNaoEncontradoException.class, () -> buscarMedicoUsecase.buscarPorCPM(crmInvalido));
+    }
+
+    @Test
+    void deveListarTodosOsMedicos() {
+        List<Medico> medicos = List.of(medico);
+        when(repository.listarTodos()).thenReturn(medicos);
+
+        List<Medico> resultado = buscarMedicoUsecase.listarTodos();
+
+        assertEquals(1, resultado.size());
+        assertEquals(medico, resultado.get(0));
+        verify(repository).listarTodos();
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/medico/CriarMedicoUsecaseTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/medico/CriarMedicoUsecaseTest.java
@@ -1,0 +1,42 @@
+package br.com.universus.gerenciador_reserva.application.usecases.medico;
+
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CriarMedicoUsecaseTest {
+
+    @Mock
+    private MedicoRepository repository;
+
+    private CriarMedicoUsecase criarMedicoUsecase;
+
+    private Medico medico;
+
+    @BeforeEach
+    void setup() {
+        criarMedicoUsecase = new CriarMedicoUsecase(repository);
+        medico = gerarMedico();
+    }
+
+    @Test
+    void deveCadastrarMedicoComSucesso() {
+        when(repository.cadastrarMedico(medico)).thenReturn(medico);
+
+        Medico resultado = criarMedicoUsecase.cadastrarMedico(medico);
+
+        assertEquals(medico, resultado);
+        verify(repository).cadastrarMedico(medico);
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/medico/DeletarMedicoUsecaseTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/medico/DeletarMedicoUsecaseTest.java
@@ -1,0 +1,34 @@
+package br.com.universus.gerenciador_reserva.application.usecases.medico;
+
+import br.com.universus.gerenciador_reserva.application.gateways.MedicoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeletarMedicoUsecaseTest {
+
+    @Mock
+    private MedicoRepository repository;
+
+    private DeletarMedicoUsecase deletarMedicoUsecase;
+
+    @BeforeEach
+    void setup() {
+        deletarMedicoUsecase = new DeletarMedicoUsecase(repository);
+    }
+
+    @Test
+    void deveDeletarMedicoPorCrmComSucesso() {
+        String crm = "12345-6/SP";
+
+        deletarMedicoUsecase.deletarPorCPF(crm);
+
+        verify(repository).deletarPorCRM(crm);
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/BuscarReservaUsecaseTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/BuscarReservaUsecaseTest.java
@@ -1,6 +1,8 @@
 package br.com.universus.gerenciador_reserva.application.usecases.reserva;
 
 import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
+import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,10 +12,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
@@ -24,12 +26,16 @@ class BuscarReservaUsecaseTest {
 
     @Mock
     private ReservaRepository repository;
+    @Mock
+    private BuscarMedicoUsecase buscarMedico;
 
-    private BuscarReservaUsecase useCase;
+    private BuscarReservaUsecase buscarReserva;
+    private Medico medico;
 
     @BeforeEach
     void setUp() {
-        useCase = new BuscarReservaUsecase(repository);
+        medico = gerarMedico();
+        buscarReserva = new BuscarReservaUsecase(repository, buscarMedico);
     }
 
     @Test
@@ -41,12 +47,12 @@ class BuscarReservaUsecaseTest {
         // Simula 3 segundas com todos horários disponíveis
         for (int i = 0; i < 3; i++) {
             LocalDate data = primeiraSegunda.plusWeeks(i);
-            when(repository.buscaReservasPorMedicoEData(nomeMedico, data))
+            when(repository.buscaReservasPorMedicoEData(medico, data))
                     .thenReturn(Collections.emptyList()); // Nenhuma reserva
         }
 
         // Act
-        List<List<LocalDateTime>> resultado = useCase.buscarProximosHorariosDisponiveis(nomeMedico, null);
+        List<List<LocalDateTime>> resultado = buscarReserva.buscarProximosHorariosDisponiveis(nomeMedico, null);
 
         // Assert
         assertEquals(3, resultado.size(), "Deveria retornar 3 semanas com horários disponíveis");
@@ -58,7 +64,7 @@ class BuscarReservaUsecaseTest {
 
         // Verifica que chamou o repositório exatamente 3 vezes
         for (int i = 0; i < 3; i++) {
-            verify(repository).buscaReservasPorMedicoEData(nomeMedico, primeiraSegunda.plusWeeks(i));
+            verify(repository).buscaReservasPorMedicoEData(medico, primeiraSegunda.plusWeeks(i));
         }
     }
 

--- a/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/CriarReservaUsecaseTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/CriarReservaUsecaseTest.java
@@ -3,100 +3,75 @@ package br.com.universus.gerenciador_reserva.application.usecases.reserva;
 import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
 import br.com.universus.gerenciador_reserva.application.usecases.medico.BuscarMedicoUsecase;
 import br.com.universus.gerenciador_reserva.domain.models.Reserva;
-import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoDiaException;
-import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoHorarioException;
 import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaIndisponivelException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static br.com.universus.gerenciador_reserva.utils.ReservaHelper.gerarReserva;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CriarReservaUsecaseTest {
 
     @Mock
-    private ReservaRepository repository;
+    private ReservaRepository reservaRepository;
 
     @Mock
-    private BuscarMedicoUsecase buscarMedicoUseCase;
-    private CriarReservaUsecase useCase;
+    private BuscarMedicoUsecase buscarMedicoUsecase;
+
+    @InjectMocks
+    private CriarReservaUsecase usecase;
 
     private Reserva reserva;
 
     @BeforeEach
-    void setUp() {
-        useCase = new CriarReservaUsecase(repository, buscarMedicoUseCase);
-        reserva = gerarReserva();
+    void setup() {
+        reserva = gerarReserva(); // já contém médico e horário válido
     }
 
     @Test
-    void deveCadastrarReservaQuandoHorarioEstiverDisponivel() {
-        // Arrange
+    void deveCadastrarReservaComSucesso() {
+        when(buscarMedicoUsecase.buscarPorCPM(reserva.getMedico().getCrm()))
+                .thenReturn(reserva.getMedico());
 
-        when(repository.buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva()))
+        when(reservaRepository.buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva()))
                 .thenReturn(Optional.empty());
 
-        when(repository.cadastrarReserva(reserva)).thenReturn(reserva);
+        when(reservaRepository.cadastrarReserva(reserva))
+                .thenReturn(reserva);
 
-        // Act
-        Reserva resultado = useCase.cadastrarReserva(reserva);
+        Reserva resultado = usecase.cadastrarReserva(reserva);
 
-        // Assert
-        assertNotNull(resultado);
-        assertEquals("João", resultado.getNomePaciente());
-        verify(repository).buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva());
-        verify(repository).cadastrarReserva(reserva);
+        assertThat(resultado).isEqualTo(reserva);
+
+        verify(buscarMedicoUsecase).buscarPorCPM(reserva.getMedico().getCrm());
+        verify(reservaRepository).buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva());
+        verify(reservaRepository).cadastrarReserva(reserva);
     }
 
     @Test
     void deveLancarExcecaoQuandoHorarioEstiverIndisponivel() {
+        when(buscarMedicoUsecase.buscarPorCPM(reserva.getMedico().getCrm()))
+                .thenReturn(reserva.getMedico());
 
-        when(repository.buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva()))
-                .thenReturn(Optional.of(reserva)); // Já existe reserva nesse horário
+        when(reservaRepository.buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva()))
+                .thenReturn(Optional.of(reserva));
 
-        // Act & Assert
-        ReservaIndisponivelException ex = assertThrows(
-                ReservaIndisponivelException.class,
-                () -> useCase.cadastrarReserva(reserva)
-        );
+        assertThatThrownBy(() -> usecase.cadastrarReserva(reserva))
+                .isInstanceOf(ReservaIndisponivelException.class)
+                .hasMessageContaining("Esse horário de reserva não está disponível.");
 
-        assertEquals("Esse horário de reserva não está disponível.", ex.getMessage());
-        verify(repository).buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva());
-        verify(repository, never()).cadastrarReserva(any());
-    }
-
-    @Test
-    void deveLancarExcecaoQuandoHorarioForForaDaSegunda() {
-        // Arrange
-        LocalDateTime sexta = LocalDateTime.of(2025, 7, 25, 16, 30); // Sexta-feira
-
-        ReservaForaDoDiaException ex = assertThrows(
-                ReservaForaDoDiaException.class,
-                () -> new Reserva(null, "Joana", reserva.getMedico(), sexta)
-        );
-
-        assertEquals("As reservas só podem ser feitas às segundas-feiras.", ex.getMessage());
-    }
-
-    @Test
-    void deveLancarExcecaoQuandoHorarioForInvalido() {
-        // Arrange
-        LocalDateTime segundaHorarioInvalido = LocalDateTime.of(2025, 7, 21, 15, 45); // Segunda, mas 15:45
-
-        ReservaForaDoHorarioException ex = assertThrows(
-                ReservaForaDoHorarioException.class,
-                () -> new Reserva(null, "Pedro", reserva.getMedico(), segundaHorarioInvalido)
-        );
-
-        assertTrue(ex.getMessage().contains("Horário fora do intervalo permitido"));
+        verify(buscarMedicoUsecase).buscarPorCPM(reserva.getMedico().getCrm());
+        verify(reservaRepository).buscarReservaExistente(reserva.getMedico(), reserva.getDataReserva());
+        verify(reservaRepository, never()).cadastrarReserva(any());
     }
 }
+
 

--- a/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/DeletarReservaUsecaseTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/application/usecases/reserva/DeletarReservaUsecaseTest.java
@@ -1,0 +1,45 @@
+package br.com.universus.gerenciador_reserva.application.usecases.reserva;
+
+import br.com.universus.gerenciador_reserva.application.gateways.ReservaRepository;
+import br.com.universus.gerenciador_reserva.domain.models.Reserva;
+import br.com.universus.gerenciador_reserva.utils.ReservaHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeletarReservaUsecaseTest {
+
+    @Mock
+    private ReservaRepository reservaRepository;
+
+    @Mock
+    private BuscarReservaUsecase buscarReservaUsecase;
+
+    @InjectMocks
+    private DeletarReservaUsecase usecase;
+
+    private Reserva reserva;
+
+    @BeforeEach
+    void setup() {
+        reserva = ReservaHelper.gerarReserva();
+    }
+
+    @Test
+    void deveDeletarReservaComSucesso() {
+        when(buscarReservaUsecase.buscarPorId(reserva.getId())).thenReturn(reserva);
+
+        usecase.deletarPorId(reserva.getId());
+
+        verify(buscarReservaUsecase).buscarPorId(reserva.getId());
+        verify(reservaRepository).deletarPorId(reserva.getId());
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/domain/models/MedicoTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/domain/models/MedicoTest.java
@@ -1,0 +1,62 @@
+package br.com.universus.gerenciador_reserva.domain.models;
+
+import br.com.universus.gerenciador_reserva.infra.exceptions.CRMForaDoPadraoException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MedicoTest {
+
+    private String nomeValido;
+
+    @BeforeEach
+    void setup() {
+        nomeValido = "Dr. João Pedro Silva";
+    }
+
+    @Test
+    @DisplayName("Deve criar um médico com CRM válido")
+    void deveCriarMedicoComCrmValido() {
+        String crmValido = "12345-6/SP";
+
+        Medico medico = new Medico(crmValido, nomeValido);
+
+        assertThat(medico.getCrm()).isEqualTo(crmValido);
+        assertThat(medico.getNome()).isEqualTo(nomeValido);
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção se o CRM for nulo")
+    void deveLancarExcecaoSeCrmForNulo() {
+        assertThatThrownBy(() -> new Medico(null, nomeValido))
+                .isInstanceOf(CRMForaDoPadraoException.class)
+                .hasMessageContaining("CRM não pode ser nulo ou vazio");
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção se o CRM for vazio")
+    void deveLancarExcecaoSeCrmForVazio() {
+        assertThatThrownBy(() -> new Medico("   ", nomeValido))
+                .isInstanceOf(CRMForaDoPadraoException.class)
+                .hasMessageContaining("CRM não pode ser nulo ou vazio");
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção se o CRM estiver fora do padrão")
+    void deveLancarExcecaoSeCrmForInvalido() {
+        assertThatThrownBy(() -> new Medico("ABC-123/SP", nomeValido))
+                .isInstanceOf(CRMForaDoPadraoException.class)
+                .hasMessageContaining("CRM fora do padrão");
+    }
+
+    @Test
+    @DisplayName("Deve aceitar CRM que respeita o padrão")
+    void deveAceitarCrmComPadraoCorreto() {
+        String crmValido = "54321-9/MG";
+        Medico medico = new Medico(crmValido, nomeValido);
+
+        assertThat(medico.getCrm()).isEqualTo(crmValido);
+    }
+}

--- a/src/test/java/br/com/universus/gerenciador_reserva/domain/models/ReservaTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/domain/models/ReservaTest.java
@@ -3,113 +3,79 @@ package br.com.universus.gerenciador_reserva.domain.models;
 import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoDiaException;
 import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoHorarioException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 class ReservaTest {
 
-    private Medico medico;
+    private Medico medicoValido;
+    private String nomePaciente;
 
     @BeforeEach
-    void setup(){
-        medico = gerarMedico();
-    }
-
-
-    @Test
-    void deveCriarReservaComDataValida() {
-        // Arrange
-        LocalDateTime data = LocalDate.of(2025, 7, 21).atTime(16, 30); // Segunda-feira, horário válido
-
-        // Act
-        Reserva reserva = new Reserva(1L, "João", medico, data);
-
-        // Assert
-        assertEquals("João", reserva.getNomePaciente());
-        assertEquals(medico, reserva.getMedico());
-        assertEquals(data, reserva.getDataReserva());
+    void setup() {
+        medicoValido = new Medico("12345-6/SP", "Dr. João Pedro Silva");
+        nomePaciente = "Ana Carolina";
     }
 
     @Test
-    void deveLancarExcecaoSeNaoForSegundaFeira() {
-        // Sexta-feira
-        LocalDateTime sexta = LocalDate.of(2025, 7, 25).atTime(16, 30);
+    @DisplayName("Deve criar uma reserva válida em segunda-feira às 16:30")
+    void deveCriarReservaValida() {
+        LocalDateTime segundaFeira1630 = LocalDateTime.of(2025, 7, 21, 16, 30);
 
-        ReservaForaDoDiaException ex = assertThrows(
-                ReservaForaDoDiaException.class,
-                () -> new Reserva(1L, "João", medico, sexta)
-        );
+        Reserva reserva = new Reserva(1L, nomePaciente, medicoValido, segundaFeira1630);
 
-        assertEquals("As reservas só podem ser feitas às segundas-feiras.", ex.getMessage());
+        assertThat(reserva.getId()).isEqualTo(1L);
+        assertThat(reserva.getNomePaciente()).isEqualTo(nomePaciente);
+        assertThat(reserva.getMedico()).isEqualTo(medicoValido);
+        assertThat(reserva.getDataReserva()).isEqualTo(segundaFeira1630);
     }
 
     @Test
-    void deveLancarExcecaoSeHoraForAntesDas16h() {
-        LocalDateTime data = LocalDate.of(2025, 7, 21).atTime(15, 30); // Segunda, mas fora do horário
+    @DisplayName("Deve lançar exceção se reserva for em dia que não é segunda-feira")
+    void deveLancarExcecaoSeReservaNaoForSegunda() {
+        LocalDateTime tercaFeira = LocalDateTime.of(2025, 7, 22, 16, 30);
 
-        ReservaForaDoHorarioException ex = assertThrows(
-                ReservaForaDoHorarioException.class,
-                () -> new Reserva(1L, "Maria", medico, data)
-        );
-
-        assertTrue(ex.getMessage().contains("Horário fora do intervalo permitido"));
+        assertThatThrownBy(() ->
+                new Reserva(1L, nomePaciente, medicoValido, tercaFeira))
+                .isInstanceOf(ReservaForaDoDiaException.class)
+                .hasMessageContaining("As reservas só podem ser feitas às segundas-feiras");
     }
 
     @Test
-    void deveLancarExcecaoSeHoraForDepoisDas18h30() {
-        LocalDateTime data = LocalDate.of(2025, 7, 21).atTime(19, 0);
+    @DisplayName("Deve lançar exceção se o horário for antes das 16h")
+    void deveLancarExcecaoSeHorarioAntesDas16() {
+        LocalDateTime segunda1530 = LocalDateTime.of(2025, 7, 21, 15, 30);
 
-        ReservaForaDoHorarioException ex = assertThrows(
-                ReservaForaDoHorarioException.class,
-                () -> new Reserva(1L, "Maria", medico, data)
-        );
-
-        assertTrue(ex.getMessage().contains("Horário fora do intervalo permitido"));
+        assertThatThrownBy(() ->
+                new Reserva(1L, nomePaciente, medicoValido, segunda1530))
+                .isInstanceOf(ReservaForaDoHorarioException.class)
+                .hasMessageContaining("Horário fora do intervalo permitido");
     }
 
     @Test
-    void deveLancarExcecaoSeMinutoForDiferenteDeZeroOuTrinta() {
-        LocalDateTime data = LocalDate.of(2025, 7, 21).atTime(17, 15); // Segunda, mas 15 minutos
+    @DisplayName("Deve lançar exceção se o horário for depois das 18:30")
+    void deveLancarExcecaoSeHorarioDepoisDas1830() {
+        LocalDateTime segunda1900 = LocalDateTime.of(2025, 7, 21, 19, 0);
 
-        ReservaForaDoHorarioException ex = assertThrows(
-                ReservaForaDoHorarioException.class,
-                () -> new Reserva(1L, "Pedro", medico, data)
-        );
-
-        assertEquals("Horários válidos apenas de 30 em 30 minutos.", ex.getMessage());
+        assertThatThrownBy(() ->
+                new Reserva(1L, nomePaciente, medicoValido, segunda1900))
+                .isInstanceOf(ReservaForaDoHorarioException.class)
+                .hasMessageContaining("Horário fora do intervalo permitido");
     }
 
     @Test
-    void deveLancarExcecaoSeNomePacienteForNull() {
-        LocalDateTime data = LocalDate.of(2025, 7, 21).atTime(16, 0);
+    @DisplayName("Deve lançar exceção se o horário não for múltiplo de 30 minutos")
+    void deveLancarExcecaoSeHorarioInvalido() {
+        LocalDateTime segunda1745 = LocalDateTime.of(2025, 7, 21, 17, 45);
 
-        assertThrows(
-                NullPointerException.class,
-                () -> new Reserva(1L, null, medico, data)
-        );
-    }
-
-    @Test
-    void deveLancarExcecaoSeNomeMedicoForNull() {
-        LocalDateTime data = LocalDate.of(2025, 7, 21).atTime(16, 0);
-
-        assertThrows(
-                NullPointerException.class,
-                () -> new Reserva(1L, "Lucas", null, data)
-        );
-    }
-
-    @Test
-    void deveLancarExcecaoSeDataForNull() {
-        assertThrows(
-                NullPointerException.class,
-                () -> new Reserva(1L, "Lucas", medico, null)
-        );
+        assertThatThrownBy(() ->
+                new Reserva(1L, nomePaciente, medicoValido, segunda1745))
+                .isInstanceOf(ReservaForaDoHorarioException.class)
+                .hasMessageContaining("Horários válidos apenas de 30 em 30 minutos");
     }
 }
 

--- a/src/test/java/br/com/universus/gerenciador_reserva/domain/models/ReservaTest.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/domain/models/ReservaTest.java
@@ -2,14 +2,24 @@ package br.com.universus.gerenciador_reserva.domain.models;
 
 import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoDiaException;
 import br.com.universus.gerenciador_reserva.infra.exceptions.ReservaForaDoHorarioException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ReservaTest {
+
+    private Medico medico;
+
+    @BeforeEach
+    void setup(){
+        medico = gerarMedico();
+    }
+
 
     @Test
     void deveCriarReservaComDataValida() {
@@ -17,11 +27,11 @@ class ReservaTest {
         LocalDateTime data = LocalDate.of(2025, 7, 21).atTime(16, 30); // Segunda-feira, horário válido
 
         // Act
-        Reserva reserva = new Reserva(1L, "João", "Dra. Ana", data);
+        Reserva reserva = new Reserva(1L, "João", medico, data);
 
         // Assert
         assertEquals("João", reserva.getNomePaciente());
-        assertEquals("Dra. Ana", reserva.getNomeMedico());
+        assertEquals(medico, reserva.getMedico());
         assertEquals(data, reserva.getDataReserva());
     }
 
@@ -32,7 +42,7 @@ class ReservaTest {
 
         ReservaForaDoDiaException ex = assertThrows(
                 ReservaForaDoDiaException.class,
-                () -> new Reserva(1L, "João", "Dra. Ana", sexta)
+                () -> new Reserva(1L, "João", medico, sexta)
         );
 
         assertEquals("As reservas só podem ser feitas às segundas-feiras.", ex.getMessage());
@@ -44,7 +54,7 @@ class ReservaTest {
 
         ReservaForaDoHorarioException ex = assertThrows(
                 ReservaForaDoHorarioException.class,
-                () -> new Reserva(1L, "Maria", "Dr. Carlos", data)
+                () -> new Reserva(1L, "Maria", medico, data)
         );
 
         assertTrue(ex.getMessage().contains("Horário fora do intervalo permitido"));
@@ -56,7 +66,7 @@ class ReservaTest {
 
         ReservaForaDoHorarioException ex = assertThrows(
                 ReservaForaDoHorarioException.class,
-                () -> new Reserva(1L, "Maria", "Dr. Carlos", data)
+                () -> new Reserva(1L, "Maria", medico, data)
         );
 
         assertTrue(ex.getMessage().contains("Horário fora do intervalo permitido"));
@@ -68,7 +78,7 @@ class ReservaTest {
 
         ReservaForaDoHorarioException ex = assertThrows(
                 ReservaForaDoHorarioException.class,
-                () -> new Reserva(1L, "Pedro", "Dra. Luiza", data)
+                () -> new Reserva(1L, "Pedro", medico, data)
         );
 
         assertEquals("Horários válidos apenas de 30 em 30 minutos.", ex.getMessage());
@@ -80,7 +90,7 @@ class ReservaTest {
 
         assertThrows(
                 NullPointerException.class,
-                () -> new Reserva(1L, null, "Dr. Paulo", data)
+                () -> new Reserva(1L, null, medico, data)
         );
     }
 
@@ -98,7 +108,7 @@ class ReservaTest {
     void deveLancarExcecaoSeDataForNull() {
         assertThrows(
                 NullPointerException.class,
-                () -> new Reserva(1L, "Lucas", "Dr. Paulo", null)
+                () -> new Reserva(1L, "Lucas", medico, null)
         );
     }
 }

--- a/src/test/java/br/com/universus/gerenciador_reserva/persistence/gateways/MedicoRepositoryJPAImplIT.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/persistence/gateways/MedicoRepositoryJPAImplIT.java
@@ -1,0 +1,61 @@
+package br.com.universus.gerenciador_reserva.persistence.gateways;
+
+
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
+import br.com.universus.gerenciador_reserva.infra.persistence.gateways.MedicoRepositoryJPAImpl;
+import br.com.universus.gerenciador_reserva.infra.persistence.repository.MedicoRepositoryJPA;
+import br.com.universus.gerenciador_reserva.utils.MedicoHelper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({MedicoRepositoryJPAImpl.class, MedicoMapper.class})
+class MedicoRepositoryJPAImplIT {
+
+    @Autowired
+    private MedicoRepositoryJPAImpl medicoRepository;
+
+    @Autowired
+    private MedicoRepositoryJPA repository;
+
+    @Test
+    void deveSalvarEMedico() {
+        Medico medico = MedicoHelper.gerarMedico();
+        Medico salvo = medicoRepository.cadastrarMedico(medico);
+
+        assertNotNull(salvo);
+        assertEquals(medico.getCrm(), salvo.getCrm());
+    }
+
+    @Test
+    void deveBuscarMedicoPorCRM() {
+        MedicoEntity entity = MedicoHelper.gerarMedicoEntity(MedicoHelper.gerarMedico());
+        repository.save(entity);
+
+        Optional<Medico> encontrado = medicoRepository.buscarPorCRM(entity.getCrm());
+
+        assertTrue(encontrado.isPresent());
+        assertEquals(entity.getCrm(), encontrado.get().getCrm());
+    }
+
+    @Test
+    void deveDeletarMedicoPorCRM() {
+        MedicoEntity entity = MedicoHelper.gerarMedicoEntity(MedicoHelper.gerarMedico());
+        repository.save(entity);
+
+        medicoRepository.deletarPorCRM(entity.getCrm());
+
+        assertTrue(repository.findById(entity.getCrm()).isEmpty());
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/persistence/gateways/ReservaRepositoryJPAImplIT.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/persistence/gateways/ReservaRepositoryJPAImplIT.java
@@ -1,0 +1,95 @@
+package br.com.universus.gerenciador_reserva.persistence.gateways;
+
+import br.com.universus.gerenciador_reserva.adapter.mapper.MedicoMapper;
+import br.com.universus.gerenciador_reserva.adapter.mapper.ReservaMapper;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.domain.models.Reserva;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
+import br.com.universus.gerenciador_reserva.infra.persistence.gateways.ReservaRepositoryJPAImpl;
+import br.com.universus.gerenciador_reserva.infra.persistence.repository.MedicoRepositoryJPA;
+import br.com.universus.gerenciador_reserva.infra.persistence.repository.ReservaRepositoryJPA;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedicoEntity;
+import static br.com.universus.gerenciador_reserva.utils.ReservaHelper.gerarReserva;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({ReservaRepositoryJPAImpl.class, ReservaMapper.class, MedicoMapper.class})
+class ReservaRepositoryJPAImplIT {
+
+    @Autowired
+    private ReservaRepositoryJPAImpl reservaRepository;
+
+    @Autowired
+    private ReservaRepositoryJPA reservaJPA;
+
+    @Autowired
+    private MedicoRepositoryJPA medicoRepository;
+
+    private Medico medico;
+    private MedicoEntity medicoEntity;
+    private Reserva reserva;
+
+    @BeforeEach
+    void setup() {
+        medico = gerarMedico();
+        medicoEntity = gerarMedicoEntity(medico);
+        medicoEntity = medicoRepository.save(medicoEntity);
+
+        reserva = gerarReserva();
+    }
+
+    @Test
+    void deveSalvarEBuscarReserva() {
+
+        Reserva salva = reservaRepository.cadastrarReserva(reserva);
+
+        Optional<Reserva> buscada = reservaRepository.buscarPorId(salva.getId());
+
+        assertTrue(buscada.isPresent());
+        assertEquals(salva.getId(), buscada.get().getId());
+    }
+
+//    @Test
+//    void deveBuscarReservasPorMedicoEData() {
+//        reservaRepository.cadastrarReserva(reserva);
+//
+//        List<LocalDateTime> horarios = reservaRepository
+//                .buscaReservasPorMedicoEData(medico, reserva.getDataReserva().toLocalDate());
+//
+//        assertFalse(horarios.isEmpty());
+//        assertTrue(horarios.contains(reserva.getDataReserva()));
+//    }
+
+    @Test
+    void deveBuscarReservaExistente() {
+        reservaRepository.cadastrarReserva(reserva);
+
+        Optional<Reserva> existente = reservaRepository
+                .buscarReservaExistente(medico, reserva.getDataReserva());
+
+        assertTrue(existente.isPresent());
+        assertEquals(reserva.getDataReserva(), existente.get().getDataReserva());
+    }
+
+    @Test
+    void deveDeletarReservaPorId() {
+        Reserva reserva = reservaRepository.cadastrarReserva(gerarReserva());
+        reservaRepository.deletarPorId(reserva.getId());
+
+        assertTrue(reservaJPA.findById(reserva.getId()).isEmpty());
+    }
+}
+

--- a/src/test/java/br/com/universus/gerenciador_reserva/utils/MedicoHelper.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/utils/MedicoHelper.java
@@ -1,0 +1,25 @@
+package br.com.universus.gerenciador_reserva.utils;
+
+import br.com.universus.gerenciador_reserva.adapter.dto.medico.MedicoDTO;
+import br.com.universus.gerenciador_reserva.domain.models.Medico;
+import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEntity;
+
+public class MedicoHelper {
+
+    public static Medico gerarMedico(){
+        return new Medico("CRM-SP-123456",
+                "Dr. João Pedro Silva");
+    }
+
+    public static MedicoDTO gerarMedicoDto (Medico medico){
+        return new MedicoDTO(medico.getCrm(),
+                medico.getNome());
+    }
+
+    public static MedicoEntity gerarMedicoEntity (Medico medico){
+        return new MedicoEntity(medico.getCrm(),
+                medico.getNome());
+    }
+
+
+}

--- a/src/test/java/br/com/universus/gerenciador_reserva/utils/MedicoHelper.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/utils/MedicoHelper.java
@@ -7,7 +7,7 @@ import br.com.universus.gerenciador_reserva.infra.persistence.entities.MedicoEnt
 public class MedicoHelper {
 
     public static Medico gerarMedico(){
-        return new Medico("CRM-SP-123456",
+        return new Medico("12345-6/SP",
                 "Dr. João Pedro Silva");
     }
 

--- a/src/test/java/br/com/universus/gerenciador_reserva/utils/ReservaHelper.java
+++ b/src/test/java/br/com/universus/gerenciador_reserva/utils/ReservaHelper.java
@@ -1,31 +1,34 @@
 package br.com.universus.gerenciador_reserva.utils;
 
-import br.com.universus.gerenciador_reserva.adapter.dto.ReservaDTO;
+import br.com.universus.gerenciador_reserva.adapter.dto.reserva.ReservaDTO;
 import br.com.universus.gerenciador_reserva.domain.models.Reserva;
 import br.com.universus.gerenciador_reserva.infra.persistence.entities.ReservaEntity;
 
 import java.time.LocalDateTime;
+
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedico;
+import static br.com.universus.gerenciador_reserva.utils.MedicoHelper.gerarMedicoEntity;
 
 public class ReservaHelper {
 
     public static Reserva gerarReserva(){
         return new Reserva(1L,
                 "Alberto",
-                "João",
+                gerarMedico(),
                 LocalDateTime.of(2025, 7, 28, 17, 30));
     }
 
     public static ReservaDTO gerarReservaDto (Reserva reserva){
         return new ReservaDTO(reserva.getId(),
                 reserva.getNomePaciente(),
-                reserva.getNomeMedico(),
+                reserva.getMedico().getNome(),
                 reserva.getDataReserva());
     }
 
     public static ReservaEntity gerarReservaEntity (Reserva reserva){
         return new ReservaEntity(reserva.getId(),
                 reserva.getNomePaciente(),
-                reserva.getNomeMedico(),
+                gerarMedicoEntity(reserva.getMedico()),
                 reserva.getDataReserva());
     }
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,12 @@
+# H2 em memória
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA/Hibernate
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Desativa Flyway para testes
+spring.flyway.enabled=false


### PR DESCRIPTION
Remove o campo 'nomeMedico' da entidade Reserva e estabelece um relacionamento
com a nova entidade 'Medico'.

Motivação:
- Melhorar a integridade referencial e o modelo de dados.
- Permitir o gerenciamento detalhado de médicos (crm, nome.).

Mudanças:
- Criada a entidade 'Medico' (crm, nome.).
- Alterada a entidade 'Reserva' para ter um objeto 'Medico'.
- Atualizado o `CriarReservaUsecase` para buscar/validar o médico.
- Modificado o `ReservaMapper` para incluir o objeto 'Medico' na conversão.
- Adicionadas validações de CRM.